### PR TITLE
Fix typing for journal event service

### DIFF
--- a/ui/src/app/journal/journal-api.service.ts
+++ b/ui/src/app/journal/journal-api.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient }   from '@angular/common/http';
 import { Observable }   from 'rxjs';
 import { environment }  from '../../environments/environment';
-import {JournalEntry, PaginatedJournalEntries} from './journal.models';
+import {JournalEntry, JournalEvent, PaginatedJournalEntries} from './journal.models';
 
 @Injectable({ providedIn: 'root' })
 export class JournalApiService {
@@ -26,7 +26,7 @@ export class JournalApiService {
     );
   }
 
-  addEvent(entryId: string, ev: Event): Observable<JournalEntry> {
+  addEvent(entryId: string, ev: JournalEvent): Observable<JournalEntry> {
     return this.http.post<JournalEntry>(
       `${this.base}/${entryId}/events`, ev
     );

--- a/ui/src/app/journal/journal.models.ts
+++ b/ui/src/app/journal/journal.models.ts
@@ -1,14 +1,16 @@
+export interface JournalEvent {
+  time: string;
+  price: number;
+  note: string;
+}
+
 export interface JournalEntry {
   id: string;            // uuid
   date: string;
   esPrice: number;
   delta: number;
   notes: string;
-  events: {
-    time: string;
-    price: number;
-    note: string;
-  }[];
+  events: JournalEvent[];
   marketDirection: 'up' | 'down';
 }
 


### PR DESCRIPTION
## Summary
- clarify API service types by introducing `JournalEvent` interface
- use `JournalEvent` in service method

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f65452d14832e9be36a882b9265d2