### PR TITLE
Add delete button for journal entries

### DIFF
--- a/ui/src/app/journal/journal-entry-form/journal-entry-form.component.html
+++ b/ui/src/app/journal/journal-entry-form/journal-entry-form.component.html
@@ -78,18 +78,32 @@
     </div>
   </div>
 
-  <button mat-button type="button" (click)="addEvent()">
-    Add Intra-day Note
-  </button>
-  <button mat-button
-          type="button"
-          (click)="cancel()"
-          *ngIf="form.get('id')?.value">
-    Clear
-  </button>
-  <button mat-raised-button
-          color="primary"
-          type="submit">
-    {{ form.get('id')?.value ? 'Update' : 'Save' }} Entry
-  </button>
+  <div class="button-row">
+    <div class="left-buttons">
+      <button mat-button type="button" (click)="addEvent()">
+        Add Intra-day Note
+      </button>
+      <button mat-button
+              type="button"
+              (click)="cancel()"
+              *ngIf="form.get('id')?.value">
+        Clear
+      </button>
+      <button mat-raised-button
+              color="primary"
+              type="submit">
+        {{ form.get('id')?.value ? 'Update' : 'Save' }} Entry
+      </button>
+    </div>
+
+    <div class="right-buttons">
+      <button mat-stroked-button
+              color="warn"
+              type="button"
+              (click)="confirmDelete()"
+              *ngIf="form.get('id')?.value">
+        Delete
+      </button>
+    </div>
+  </div>
 </form>

--- a/ui/src/app/journal/journal-entry-form/journal-entry-form.component.scss
+++ b/ui/src/app/journal/journal-entry-form/journal-entry-form.component.scss
@@ -24,3 +24,19 @@ form {
   gap: 8px;
 }
 
+.button-row {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 16px;
+}
+
+.left-buttons {
+  display: flex;
+  gap: 8px;
+}
+
+.right-buttons {
+  display: flex;
+  gap: 8px;
+}
+

--- a/ui/src/app/journal/journal-entry-form/journal-entry-form.component.ts
+++ b/ui/src/app/journal/journal-entry-form/journal-entry-form.component.ts
@@ -19,6 +19,7 @@ export class JournalEntryFormComponent implements OnInit, OnChanges  {
   @Input() entry?: JournalEntry;
   @Output() saved = new EventEmitter<JournalEntry>();
   @Output() cancelled = new EventEmitter<void>();
+  @Output() deleted = new EventEmitter<string>();
 
   form!: FormGroup;
 
@@ -109,5 +110,17 @@ export class JournalEntryFormComponent implements OnInit, OnChanges  {
   cancel() {
     this.resetForm();
     this.cancelled.emit();
+  }
+
+  confirmDelete() {
+    const id = this.form.get('id')?.value;
+    if (!id) return;
+
+    if (confirm('Delete this entry?')) {
+      this.api.delete(id).subscribe(() => {
+        this.deleted.emit(id);
+        this.resetForm();
+      });
+    }
   }
 }

--- a/ui/src/app/journal/journal-page/journal-page.component.html
+++ b/ui/src/app/journal/journal-page/journal-page.component.html
@@ -17,6 +17,7 @@
     [entry]="selectedEntry"
     (saved)="onEntrySaved($event)"
     (cancelled)="onEditCancelled()"
+    (deleted)="onEntryDeleted($event)"
     class="journal-form"
   ></app-journal-entry-form>
 </div>

--- a/ui/src/app/journal/journal-page/journal-page.component.ts
+++ b/ui/src/app/journal/journal-page/journal-page.component.ts
@@ -46,4 +46,10 @@ export class JournalPageComponent implements OnInit {
   onEditCancelled() {
     this.selectedEntry = undefined;
   }
+
+  onEntryDeleted(id: string) {
+    this.entries = this.entries.filter(e => e.id !== id);
+    this.totalEntries = Math.max(this.totalEntries - 1, 0);
+    this.selectedEntry = undefined;
+  }
 }


### PR DESCRIPTION
## Summary
- add delete button with confirmation to entry form
- style button row and handle delete events
- update journal page to refresh list on delete
- adjust button layout so only delete is right-aligned

## Testing
- `npm install --prefix ui`
- `npm test --prefix ui` *(fails: No Chrome binary)*


------
https://chatgpt.com/codex/tasks/task_e_683f6c0aba30832e81f256206b38b347