### PR TITLE
Fix test db cleanup

### DIFF
--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 import pytest_asyncio
 from httpx import AsyncClient
 
@@ -7,7 +8,20 @@ TEST_DB_PATH = os.path.abspath("test.db")
 # If DATABASE_URL isn't already set, point it to our temp file
 os.environ.setdefault("DATABASE_URL", f"sqlite:///{TEST_DB_PATH}")
 
+# Remove any leftover test database before importing the app so that each test
+# run starts with a clean slate.
+if os.path.exists(TEST_DB_PATH):
+    os.remove(TEST_DB_PATH)
+
 from app.main import app  # noqa: E402
+
+
+@pytest.fixture(scope="session", autouse=True)
+def cleanup_db():
+    """Delete the temporary test database once the test session is over."""
+    yield
+    if os.path.exists(TEST_DB_PATH):
+        os.remove(TEST_DB_PATH)
 
 @pytest_asyncio.fixture
 async def client():


### PR DESCRIPTION
## Summary
- ensure `test.db` is removed before and after tests so repeated test runs start with a clean database

## Testing
- `pytest -q`
- `pytest -q` (again)

------
https://chatgpt.com/codex/tasks/task_e_684076423420832ebc21f2344f0826f3