### PR TITLE
Add GET entry test

### DIFF
--- a/api/tests/test_entries_v1.py
+++ b/api/tests/test_entries_v1.py
@@ -33,3 +33,24 @@ async def test_create_entry(client):
     assert list_data["total"] == 1
     assert len(list_data["items"]) == 1
 
+
+@pytest.mark.asyncio
+async def test_get_created_entry(client):
+    """Create an entry then fetch it by id."""
+    create_resp = await client.post("/v1/entries", json=sample_entry)
+    assert create_resp.status_code == 201
+    created = create_resp.json()
+    entry_id = created["id"]
+
+    get_resp = await client.get(f"/v1/entries/{entry_id}")
+    assert get_resp.status_code == 200
+    fetched = get_resp.json()
+
+    assert fetched["id"] == entry_id
+    assert fetched["date"] == sample_entry["date"]
+    assert fetched["esPrice"] == sample_entry["esPrice"]
+    assert fetched["delta"] == sample_entry["delta"]
+    assert fetched["notes"] == sample_entry["notes"]
+    assert fetched["marketDirection"] == sample_entry["marketDirection"]
+    assert fetched["events"] == sample_entry["events"]
+


### PR DESCRIPTION
## Summary
- expand test suite by verifying retrieving a created entry

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407aa654c0832e92bfcd70a2d9c34e