### PR TITLE
Update pytest paths for API tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,4 +3,4 @@ addopts = -ra
 pythonpath = api
 
 # Where tests live
-testpaths = tests
+testpaths = api/tests


### PR DESCRIPTION
## Summary
- adjust `pytest.ini` to set `testpaths` to the API tests directory

## Testing
- `pip install -r api/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407aadead8832ebff91d169e4ec3bf