### PR TITLE
Add typed positions response

### DIFF
--- a/api/app/routers/v1/trades.py
+++ b/api/app/routers/v1/trades.py
@@ -5,6 +5,8 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from typing import Dict, List, Tuple
 
+from app.schema import PositionsResponse
+
 from app.db import get_db
 from app import tastytrade
 
@@ -13,7 +15,11 @@ router = APIRouter(
     tags=["v1 – trades"]
 )
 
-@router.get("", summary="Get all non-equity positions grouped by underlying-symbol and expiration")
+@router.get(
+    "",
+    summary="Get all non-equity positions grouped by underlying-symbol and expiration",
+    response_model=PositionsResponse,
+)
 def get_all_positions(db: Session = Depends(get_db)):
     """
     Retrieve all positions across all accounts, excluding:
@@ -133,4 +139,4 @@ def get_all_positions(db: Session = Depends(get_db)):
                 "groups": groups_list
             })
 
-    return {"accounts": accounts_data}
+    return PositionsResponse(accounts=accounts_data)

--- a/api/app/schema.py
+++ b/api/app/schema.py
@@ -1,6 +1,6 @@
 from datetime import date, datetime
 from enum import Enum
-from typing import List, Optional
+from typing import Any, List, Optional
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field
@@ -85,5 +85,51 @@ class SessionToken(SessionTokenBase):
 
     model_config = {
         "from_attributes": True
+    }
+
+
+class Position(BaseModel):
+    """Generic position data with arbitrary fields."""
+
+    approximate_p_l: Optional[float] = Field(None, alias="approximate-p-l")
+
+    model_config = {
+        "populate_by_name": True,
+        "extra": "allow",
+        "from_attributes": True,
+    }
+
+
+class GroupedPositions(BaseModel):
+    underlying_symbol: str
+    expires_at: str
+    total_credit_received: float
+    current_group_price: float
+    group_approximate_p_l: float
+    percent_credit_received: Optional[int] = Field(None, alias="percent-credit-received")
+    positions: List[Position]
+
+    model_config = {
+        "populate_by_name": True,
+        "from_attributes": True,
+    }
+
+
+class AccountPositions(BaseModel):
+    account_number: str
+    groups: List[GroupedPositions]
+
+    model_config = {
+        "populate_by_name": True,
+        "from_attributes": True,
+    }
+
+
+class PositionsResponse(BaseModel):
+    accounts: List[AccountPositions]
+
+    model_config = {
+        "populate_by_name": True,
+        "from_attributes": True,
     }
 


### PR DESCRIPTION
## Summary
- add `Position`, `GroupedPositions`, `AccountPositions`, `PositionsResponse`
- return `PositionsResponse` from GET /v1/trades
- show new schema in OpenAPI docs

## Testing
- `pytest -q`
- `PYTHONPATH=api uvicorn app.main:app --port 9999 --log-level warning &`
- `curl -s http://127.0.0.1:9999/openapi.json | jq '.components.schemas.PositionsResponse' | head`

------
https://chatgpt.com/codex/tasks/task_e_684371597588832ebd4e9a05f0224286