### PR TITLE
Add positions feature module

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -8,6 +8,11 @@ const routes: Routes = [
       import('./journal/journal.module').then(m => m.JournalModule)
   },
   {
+    path: 'positions',
+    loadChildren: () =>
+      import('./positions/positions.module').then(m => m.PositionsModule)
+  },
+  {
     path: '',
     redirectTo: 'journal',
     pathMatch: 'full'

--- a/ui/src/app/app.component.html
+++ b/ui/src/app/app.component.html
@@ -9,6 +9,7 @@
   <mat-sidenav #sidenav mode="side" opened class="app-sidenav">
     <mat-nav-list>
       <a mat-list-item routerLink="/journal" (click)="sidenav.close()">Journal</a>
+      <a mat-list-item routerLink="/positions" (click)="sidenav.close()">Positions</a>
       <!-- future nav items -->
     </mat-nav-list>
   </mat-sidenav>

--- a/ui/src/app/positions/positions-api.service.ts
+++ b/ui/src/app/positions/positions-api.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+import { PositionsResponse } from './positions.models';
+
+@Injectable({ providedIn: 'root' })
+export class PositionsApiService {
+  private base = `${environment.apiUrl}/trades`;
+
+  constructor(private http: HttpClient) {}
+
+  getAll(): Observable<PositionsResponse> {
+    return this.http.get<PositionsResponse>(this.base);
+  }
+}

--- a/ui/src/app/positions/positions-page/positions-page.component.html
+++ b/ui/src/app/positions/positions-page/positions-page.component.html
@@ -1,0 +1,57 @@
+<div *ngFor="let account of accounts" class="account-section">
+  <h2>Account {{ account.account_number }}</h2>
+  <table mat-table [dataSource]="account.groups" class="mat-elevation-z1 full-width">
+    <ng-container matColumnDef="underlying">
+      <th mat-header-cell *matHeaderCellDef>Underlying</th>
+      <td mat-cell *matCellDef="let g">{{ g.underlying_symbol }}</td>
+    </ng-container>
+    <ng-container matColumnDef="expires">
+      <th mat-header-cell *matHeaderCellDef>Expires</th>
+      <td mat-cell *matCellDef="let g">{{ g.expires_at }}</td>
+    </ng-container>
+    <ng-container matColumnDef="credit">
+      <th mat-header-cell *matHeaderCellDef>Total Credit</th>
+      <td mat-cell *matCellDef="let g">{{ g.total_credit_received }}</td>
+    </ng-container>
+    <ng-container matColumnDef="price">
+      <th mat-header-cell *matHeaderCellDef>Current Price</th>
+      <td mat-cell *matCellDef="let g">{{ g.current_group_price }}</td>
+    </ng-container>
+    <ng-container matColumnDef="pl">
+      <th mat-header-cell *matHeaderCellDef>P/L</th>
+      <td mat-cell *matCellDef="let g">{{ g.group_approximate_p_l }}</td>
+    </ng-container>
+    <ng-container matColumnDef="positions">
+      <th mat-header-cell *matHeaderCellDef>Positions</th>
+      <td mat-cell *matCellDef="let g">
+        <mat-expansion-panel>
+          <mat-expansion-panel-header>
+            <mat-panel-title>Show Positions</mat-panel-title>
+          </mat-expansion-panel-header>
+          <table mat-table [dataSource]="g.positions" class="mat-elevation-z1 inner-table">
+            <ng-container matColumnDef="symbol">
+              <th mat-header-cell *matHeaderCellDef>Symbol</th>
+              <td mat-cell *matCellDef="let p">{{ p['symbol'] || p['instrument-symbol'] }}</td>
+            </ng-container>
+            <ng-container matColumnDef="qty">
+              <th mat-header-cell *matHeaderCellDef>Qty</th>
+              <td mat-cell *matCellDef="let p">{{ p['quantity'] }}</td>
+            </ng-container>
+            <ng-container matColumnDef="type">
+              <th mat-header-cell *matHeaderCellDef>Type</th>
+              <td mat-cell *matCellDef="let p">{{ p['instrument-type'] }}</td>
+            </ng-container>
+            <ng-container matColumnDef="plpos">
+              <th mat-header-cell *matHeaderCellDef>P/L</th>
+              <td mat-cell *matCellDef="let p">{{ p['approximate-p-l'] }}</td>
+            </ng-container>
+            <tr mat-header-row *matHeaderRowDef="positionCols"></tr>
+            <tr mat-row *matRowDef="let row; columns: positionCols"></tr>
+          </table>
+        </mat-expansion-panel>
+      </td>
+    </ng-container>
+    <tr mat-header-row *matHeaderRowDef="groupCols"></tr>
+    <tr mat-row *matRowDef="let row; columns: groupCols"></tr>
+  </table>
+</div>

--- a/ui/src/app/positions/positions-page/positions-page.component.scss
+++ b/ui/src/app/positions/positions-page/positions-page.component.scss
@@ -1,0 +1,12 @@
+.account-section {
+  margin-bottom: 24px;
+}
+
+.full-width {
+  width: 100%;
+}
+
+.inner-table {
+  width: 100%;
+  margin-top: 8px;
+}

--- a/ui/src/app/positions/positions-page/positions-page.component.ts
+++ b/ui/src/app/positions/positions-page/positions-page.component.ts
@@ -1,0 +1,31 @@
+import { Component, OnInit } from '@angular/core';
+import { PositionsApiService } from '../positions-api.service';
+import { AccountPositions } from '../positions.models';
+
+@Component({
+  selector: 'app-positions-page',
+  templateUrl: './positions-page.component.html',
+  styleUrls: ['./positions-page.component.scss'],
+  standalone: false,
+})
+export class PositionsPageComponent implements OnInit {
+  accounts: AccountPositions[] = [];
+  groupCols = [
+    'underlying',
+    'expires',
+    'credit',
+    'price',
+    'pl',
+    'positions'
+  ];
+
+  positionCols = ['symbol', 'qty', 'type', 'plpos'];
+
+  constructor(private api: PositionsApiService) {}
+
+  ngOnInit() {
+    this.api.getAll().subscribe(res => {
+      this.accounts = res.accounts;
+    });
+  }
+}

--- a/ui/src/app/positions/positions-routing.module.ts
+++ b/ui/src/app/positions/positions-routing.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { PositionsPageComponent } from './positions-page/positions-page.component';
+
+const routes: Routes = [
+  { path: '', component: PositionsPageComponent }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class PositionsRoutingModule {}

--- a/ui/src/app/positions/positions.models.ts
+++ b/ui/src/app/positions/positions.models.ts
@@ -1,0 +1,22 @@
+export interface Position {
+  [key: string]: any;
+}
+
+export interface PositionGroup {
+  underlying_symbol: string;
+  expires_at: string;
+  total_credit_received: number;
+  current_group_price: number;
+  group_approximate_p_l: number;
+  'percent-credit-received': number | null;
+  positions: Position[];
+}
+
+export interface AccountPositions {
+  account_number: string;
+  groups: PositionGroup[];
+}
+
+export interface PositionsResponse {
+  accounts: AccountPositions[];
+}

--- a/ui/src/app/positions/positions.module.ts
+++ b/ui/src/app/positions/positions.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SharedMaterialModule } from '../shared/material.module';
+import { PositionsRoutingModule } from './positions-routing.module';
+import { PositionsPageComponent } from './positions-page/positions-page.component';
+
+@NgModule({
+  declarations: [PositionsPageComponent],
+  imports: [CommonModule, SharedMaterialModule, PositionsRoutingModule],
+})
+export class PositionsModule {}

--- a/ui/src/app/shared/material.module.ts
+++ b/ui/src/app/shared/material.module.ts
@@ -9,7 +9,8 @@ import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatIconModule } from '@angular/material/icon';
-import {MatButtonToggleModule} from '@angular/material/button-toggle';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
+import { MatTableModule } from '@angular/material/table';
 
 @NgModule({
   imports: [
@@ -23,6 +24,7 @@ import {MatButtonToggleModule} from '@angular/material/button-toggle';
     MatExpansionModule,
     MatIconModule,
     MatButtonToggleModule,
+    MatTableModule,
   ],
   exports: [
     MatSidenavModule,
@@ -34,6 +36,7 @@ import {MatButtonToggleModule} from '@angular/material/button-toggle';
     MatExpansionModule,
     MatIconModule,
     MatButtonToggleModule,
+    MatTableModule,
   ]
 })
 export class SharedMaterialModule {}


### PR DESCRIPTION
## Summary
- scaffold `PositionsModule` with routing
- add `PositionsPageComponent` and `PositionsApiService`
- show position accounts in nested Material tables
- register positions route and navigation link
- extend shared material module with `MatTableModule`

## Testing
- `npm test --silent`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6843715addc8832ea02e42de671da2d1