### PR TITLE
Rename percent_credit_received field

### DIFF
--- a/api/app/routers/v1/trades.py
+++ b/api/app/routers/v1/trades.py
@@ -32,7 +32,7 @@ def get_all_positions(db: Session = Depends(get_db)):
          - total_credit_received (rounded to 2 decimals)
          - current_group_price (rounded to 2 decimals)
          - group_approximate_p_l = total_credit_received - current_group_price (rounded to 2 decimals)
-         - percent-credit-received = int((group_approximate_p_l / total_credit_received) * 100), or None
+         - percent_credit_received = int((group_approximate_p_l / total_credit_received) * 100), or None
     """
     try:
         token = tastytrade.get_active_token(db)
@@ -117,7 +117,7 @@ def get_all_positions(db: Session = Depends(get_db)):
             current_group_price = round(current_credit_unrounded, 2)
             group_pl = round(total_credit_received - current_group_price, 2)
 
-            # Compute percent-credit-received = int((group_pl / total_credit_received) * 100)
+            # Compute percent_credit_received = int((group_pl / total_credit_received) * 100)
             if total_credit_received != 0:
                 percent_credit_received = int((group_pl / total_credit_received) * 100)
             else:
@@ -129,7 +129,7 @@ def get_all_positions(db: Session = Depends(get_db)):
                 "total_credit_received": total_credit_received,
                 "current_group_price": current_group_price,
                 "group_approximate_p_l": group_pl,
-                "percent-credit-received": percent_credit_received,
+                "percent_credit_received": percent_credit_received,
                 "positions": pos_list
             })
 

--- a/api/app/schema.py
+++ b/api/app/schema.py
@@ -106,7 +106,7 @@ class GroupedPositions(BaseModel):
     total_credit_received: float
     current_group_price: float
     group_approximate_p_l: float
-    percent_credit_received: Optional[int] = Field(None, alias="percent-credit-received")
+    percent_credit_received: Optional[int] = None
     positions: List[Position]
 
     model_config = {

--- a/api/tests/test_trades_v1.py
+++ b/api/tests/test_trades_v1.py
@@ -67,7 +67,7 @@ async def test_trades_grouped(client, monkeypatch):
                         "total_credit_received": -3.5,
                         "current_group_price": -0.7,
                         "group_approximate_p_l": -2.8,
-                        "percent-credit-received": 80,
+                        "percent_credit_received": 80,
                         "positions": [
                             {
                                 "instrument-type": "Option",

--- a/ui/src/app/positions/positions-page/positions-page.component.html
+++ b/ui/src/app/positions/positions-page/positions-page.component.html
@@ -21,6 +21,10 @@
       <th mat-header-cell *matHeaderCellDef>P/L</th>
       <td mat-cell *matCellDef="let g">{{ g.group_approximate_p_l }}</td>
     </ng-container>
+    <ng-container matColumnDef="percent">
+      <th mat-header-cell *matHeaderCellDef>% Credit</th>
+      <td mat-cell *matCellDef="let g">{{ g.percent_credit_received }}</td>
+    </ng-container>
     <ng-container matColumnDef="positions">
       <th mat-header-cell *matHeaderCellDef>Positions</th>
       <td mat-cell *matCellDef="let g">

--- a/ui/src/app/positions/positions-page/positions-page.component.ts
+++ b/ui/src/app/positions/positions-page/positions-page.component.ts
@@ -16,6 +16,7 @@ export class PositionsPageComponent implements OnInit {
     'credit',
     'price',
     'pl',
+    'percent',
     'positions'
   ];
 

--- a/ui/src/app/positions/positions.models.ts
+++ b/ui/src/app/positions/positions.models.ts
@@ -8,7 +8,7 @@ export interface PositionGroup {
   total_credit_received: number;
   current_group_price: number;
   group_approximate_p_l: number;
-  'percent-credit-received': number | null;
+  percent_credit_received: number | null;
   positions: Position[];
 }
 


### PR DESCRIPTION
## Summary
- rename the percent credit received field for the trades API
- show percent_credit_received column in UI
- adjust tests for new field name

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68437629a284832ebfe8dc5f74df60ef