### PR TITLE
Highlight active sidebar link

### DIFF
--- a/ui/src/app/app.component.html
+++ b/ui/src/app/app.component.html
@@ -8,8 +8,8 @@
 <mat-sidenav-container class="full-height">
   <mat-sidenav #sidenav mode="side" opened class="app-sidenav">
     <mat-nav-list>
-      <a mat-list-item routerLink="/journal" (click)="sidenav.close()">Journal</a>
-      <a mat-list-item routerLink="/positions" (click)="sidenav.close()">Positions</a>
+      <a mat-list-item routerLink="/journal" routerLinkActive="active-link" (click)="sidenav.close()">Journal</a>
+      <a mat-list-item routerLink="/positions" routerLinkActive="active-link" (click)="sidenav.close()">Positions</a>
       <!-- future nav items -->
     </mat-nav-list>
   </mat-sidenav>

--- a/ui/src/app/app.component.scss
+++ b/ui/src/app/app.component.scss
@@ -19,3 +19,8 @@ mat-sidenav-content {
   min-width: 200px;   /* ensure it never shrinks below */
   max-width: 200px;   /* optional if you want to lock it */
 }
+
+/* Highlight active sidebar link */
+a.active-link {
+  background-color: rgba(0, 0, 0, 0.1);
+}


### PR DESCRIPTION
## Summary
- highlight active link in the sidebar
- style active link background

## Testing
- `pytest`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68437b579d00832eb29129d4774821da