### PR TITLE
Add ES market data auto load

### DIFF
--- a/ui/src/app/journal/journal-api.service.spec.ts
+++ b/ui/src/app/journal/journal-api.service.spec.ts
@@ -66,4 +66,15 @@ describe('JournalApiService', () => {
     expect(req.request.method).toBe('DELETE');
     req.flush(null);
   });
+
+  it('getMarketData should perform POST request with body', () => {
+    const marketUrl = `${environment.apiUrl}/trades/market-data`;
+    const resp = [{ symbol: '/ESU5' }];
+
+    service.getMarketData([], [], ['/ESU5'], []).subscribe(res => expect(res).toEqual(resp));
+    const req = http.expectOne(marketUrl);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body.future).toEqual(['/ESU5']);
+    req.flush(resp);
+  });
 });

--- a/ui/src/app/journal/journal-api.service.ts
+++ b/ui/src/app/journal/journal-api.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient }   from '@angular/common/http';
 import { Observable }   from 'rxjs';
 import { environment }  from '../../environments/environment';
-import {JournalEntry, JournalEvent, PaginatedJournalEntries} from './journal.models';
+import {JournalEntry, JournalEvent, PaginatedJournalEntries, MarketData} from './journal.models';
 
 @Injectable({ providedIn: 'root' })
 export class JournalApiService {
@@ -34,5 +34,24 @@ export class JournalApiService {
 
   delete(id: string): Observable<void> {
     return this.http.delete<void>(`${this.base}/${id}`);
+  }
+
+  getMarketData(
+    equity: string[] = [],
+    equityOption: string[] = [],
+    future: string[] = [],
+    futureOption: string[] = []
+  ): Observable<MarketData[]> {
+    const body = {
+      equity,
+      equity_option: equityOption,
+      future,
+      future_option: futureOption,
+    };
+
+    return this.http.post<MarketData[]>(
+      `${environment.apiUrl}/trades/market-data`,
+      body
+    );
   }
 }

--- a/ui/src/app/journal/journal-entry-form/journal-entry-form.component.spec.ts
+++ b/ui/src/app/journal/journal-entry-form/journal-entry-form.component.spec.ts
@@ -15,7 +15,8 @@ describe('JournalEntryFormComponent', () => {
   let apiSpy: jasmine.SpyObj<JournalApiService>;
 
   beforeEach(async () => {
-    apiSpy = jasmine.createSpyObj('JournalApiService', ['create', 'update', 'delete']);
+    apiSpy = jasmine.createSpyObj('JournalApiService', ['create', 'update', 'delete', 'getMarketData']);
+    apiSpy.getMarketData.and.returnValue(of([{ mark: '6000', close: '5990' }]));
 
     await TestBed.configureTestingModule({
       declarations: [JournalEntryFormComponent],
@@ -31,6 +32,14 @@ describe('JournalEntryFormComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('ngOnInit populates form with market data', () => {
+    apiSpy.getMarketData.and.returnValue(of([{ mark: '6010.7', close: '6000' }]));
+    component.ngOnInit();
+    expect(apiSpy.getMarketData).toHaveBeenCalled();
+    expect(component.form.get('esPrice')?.value).toBe(6010);
+    expect(component.form.get('marketDirection')?.value).toBe('up');
   });
 
   it('buildForm creates expected controls with validators', () => {

--- a/ui/src/app/journal/journal-entry-form/journal-entry-form.component.ts
+++ b/ui/src/app/journal/journal-entry-form/journal-entry-form.component.ts
@@ -30,6 +30,23 @@ export class JournalEntryFormComponent implements OnInit, OnChanges  {
 
   ngOnInit() {
     this.buildForm();
+
+    this.api
+      .getMarketData([], [], ['/ESU5'], [])
+      .subscribe((data) => {
+        if (!data || !data.length) return;
+        const item = data[0];
+        const mark = parseFloat(item['mark']);
+        const close = parseFloat(item['close']);
+        if (!isNaN(mark)) {
+          this.form.patchValue({ esPrice: parseInt(String(mark), 10) });
+        }
+        if (!isNaN(mark) && !isNaN(close)) {
+          this.form.patchValue({
+            marketDirection: mark > close ? 'up' : 'down'
+          });
+        }
+      });
   }
 
   ngOnChanges(changes: SimpleChanges) {

--- a/ui/src/app/journal/journal.models.ts
+++ b/ui/src/app/journal/journal.models.ts
@@ -20,3 +20,7 @@ export interface PaginatedJournalEntries {
   skip: number;
   limit: number;
 }
+
+export interface MarketData {
+  [key: string]: any;
+}


### PR DESCRIPTION
## Summary
- fetch market data for `/ESU5` when journal form initializes
- expose `getMarketData` API call in the Angular service
- define `MarketData` interface
- update unit tests for the new service method and component logic
- test new `/v1/trades/market-data` endpoint

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684f3813d540832e9ee0b393c1012f26