### PR TITLE
Populate journal event price with market data

### DIFF
--- a/ui/src/app/journal/journal-entry-form/journal-entry-form.component.spec.ts
+++ b/ui/src/app/journal/journal-entry-form/journal-entry-form.component.spec.ts
@@ -90,13 +90,14 @@ describe('JournalEntryFormComponent', () => {
     expect(component.events.at(0).value).toEqual(entry.events[0]);
   });
 
-  it('addEvent adds new form group', () => {
+  it('addEvent adds new form group with latest price', () => {
     const len = component.events.length;
     component.addEvent();
+    expect(apiSpy.getMarketData).toHaveBeenCalled();
     expect(component.events.length).toBe(len + 1);
     const group = component.events.at(len) as any;
     expect(group.get('time')).toBeTruthy();
-    expect(group.get('price')).toBeTruthy();
+    expect(group.get('price')?.value).toBe(6000);
     expect(group.get('note')).toBeTruthy();
   });
 

--- a/ui/src/app/journal/journal-entry-form/journal-entry-form.component.ts
+++ b/ui/src/app/journal/journal-entry-form/journal-entry-form.component.ts
@@ -101,11 +101,23 @@ export class JournalEntryFormComponent implements OnInit, OnChanges  {
   }
 
   addEvent() {
-    this.events.push(this.fb.group({
+    const group = this.fb.group({
       time: [new Date().toLocaleTimeString(), Validators.required],
       price: [null, Validators.required],
       note: ['']
-    }));
+    });
+    this.events.push(group);
+
+    this.api
+      .getMarketData([], [], ['/ESU5'], [])
+      .subscribe((data) => {
+        if (!data || !data.length) return;
+        const item = data[0];
+        const mark = parseFloat(item['mark']);
+        if (!isNaN(mark)) {
+          group.patchValue({ price: parseInt(String(mark), 10) as any });
+        }
+      });
   }
 
   submit() {


### PR DESCRIPTION
## Summary
- autofill new journal event price using `/ESU5` market data
- test price population when adding an event

## Testing
- `npm test --prefix ui --silent`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684f43fae454832eb9991461c8079367