### PR TITLE
Add global loading indicators

### DIFF
--- a/ui/src/app/app.component.html
+++ b/ui/src/app/app.component.html
@@ -4,6 +4,7 @@
   </button>
   <span>My Trading App</span>
 </mat-toolbar>
+<mat-progress-bar mode="indeterminate" *ngIf="loading$ | async"></mat-progress-bar>
 
 <mat-sidenav-container class="full-height">
   <mat-sidenav #sidenav mode="side" opened class="app-sidenav">

--- a/ui/src/app/app.component.ts
+++ b/ui/src/app/app.component.ts
@@ -9,7 +9,9 @@ import { LoadingService } from './shared/loading.service';
 })
 export class AppComponent {
   view: 'journal' = 'journal';
-  loading$ = this.loadingService.loading$;
+  get loading$() {
+    return this.loadingService.loading$;
+  }
 
   constructor(private loadingService: LoadingService) {}
 }

--- a/ui/src/app/app.component.ts
+++ b/ui/src/app/app.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { LoadingService } from './shared/loading.service';
 
 @Component({
   selector: 'app-root',
@@ -8,4 +9,7 @@ import { Component } from '@angular/core';
 })
 export class AppComponent {
   view: 'journal' = 'journal';
+  loading$ = this.loadingService.loading$;
+
+  constructor(private loadingService: LoadingService) {}
 }

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -1,10 +1,11 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { HttpClientModule } from '@angular/common/http';
+import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 
 import { AppRoutingModule } from './app-routing.module';
 import { SharedMaterialModule } from './shared/material.module';
+import { LoadingInterceptor } from './shared/loading.interceptor';
 
 import { AppComponent } from './app.component';
 
@@ -18,6 +19,9 @@ import { AppComponent } from './app.component';
     HttpClientModule,
     SharedMaterialModule,
     AppRoutingModule
+  ],
+  providers: [
+    { provide: HTTP_INTERCEPTORS, useClass: LoadingInterceptor, multi: true }
   ],
   bootstrap: [AppComponent]
 })

--- a/ui/src/app/shared/loading.interceptor.ts
+++ b/ui/src/app/shared/loading.interceptor.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import {
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest
+} from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { finalize } from 'rxjs/operators';
+import { LoadingService } from './loading.service';
+
+@Injectable()
+export class LoadingInterceptor implements HttpInterceptor {
+  constructor(private loading: LoadingService) {}
+
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    this.loading.show();
+    return next.handle(req).pipe(finalize(() => this.loading.hide()));
+  }
+}

--- a/ui/src/app/shared/loading.service.ts
+++ b/ui/src/app/shared/loading.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class LoadingService {
+  private count = 0;
+  private _loading$ = new BehaviorSubject<boolean>(false);
+  readonly loading$ = this._loading$.asObservable();
+
+  show() {
+    this.count++;
+    if (!this._loading$.value) {
+      this._loading$.next(true);
+    }
+  }
+
+  hide() {
+    if (this.count > 0) {
+      this.count--;
+    }
+    if (this.count === 0 && this._loading$.value) {
+      this._loading$.next(false);
+    }
+  }
+}

--- a/ui/src/app/shared/material.module.ts
+++ b/ui/src/app/shared/material.module.ts
@@ -11,6 +11,7 @@ import { MatExpansionModule } from '@angular/material/expansion';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatTableModule } from '@angular/material/table';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
 
 @NgModule({
   imports: [
@@ -25,6 +26,7 @@ import { MatTableModule } from '@angular/material/table';
     MatIconModule,
     MatButtonToggleModule,
     MatTableModule,
+    MatProgressBarModule,
   ],
   exports: [
     MatSidenavModule,
@@ -37,6 +39,7 @@ import { MatTableModule } from '@angular/material/table';
     MatIconModule,
     MatButtonToggleModule,
     MatTableModule,
+    MatProgressBarModule,
   ]
 })
 export class SharedMaterialModule {}


### PR DESCRIPTION
## Summary
- show progress bar during HttpClient requests
- add LoadingService and HTTP interceptor
- import progress bar in Material module
- wire service to AppComponent

## Testing
- `pytest`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684f4616462c832ea69b01a258cdb9bc