### PR TITLE
Add IV rank data to positions

### DIFF
--- a/api/app/schema.py
+++ b/api/app/schema.py
@@ -107,6 +107,7 @@ class GroupedPositions(BaseModel):
     current_group_price: float
     group_approximate_p_l: float
     percent_credit_received: Optional[int] = None
+    iv_rank: Optional[float] = Field(None, alias="iv_rank")
     positions: List[Position]
 
     model_config = {

--- a/api/tests/test_trades_v1.py
+++ b/api/tests/test_trades_v1.py
@@ -45,6 +45,10 @@ async def test_trades_grouped(client, monkeypatch):
                 {"instrument-type": "Equity", "underlying-symbol": "AAPL"}
             ]
 
+    def fake_vol(token, symbols):
+        assert symbols == ["SPY"]
+        return [{"symbol": "SPY", "implied-volatility-index-rank": "0.191"}]
+
     monkeypatch.setattr(
         "app.routers.v1.trades.tastytrade.get_active_token", fake_token
     )
@@ -53,6 +57,9 @@ async def test_trades_grouped(client, monkeypatch):
     )
     monkeypatch.setattr(
         "app.routers.v1.trades.tastytrade.fetch_positions", fake_positions
+    )
+    monkeypatch.setattr(
+        "app.routers.v1.trades.tastytrade.fetch_volatility_data", fake_vol
     )
 
     resp = await client.get("/v1/trades")
@@ -72,6 +79,7 @@ async def test_trades_grouped(client, monkeypatch):
                         "current_group_price": -0.7,
                         "group_approximate_p_l": -2.8,
                         "percent_credit_received": 80,
+                        "iv_rank": 19.1,
                         "positions": [
                             {
                                 "instrument-type": "Option",

--- a/ui/src/app/positions/positions-page/positions-page.component.html
+++ b/ui/src/app/positions/positions-page/positions-page.component.html
@@ -25,6 +25,10 @@
       <th mat-header-cell *matHeaderCellDef>% Credit</th>
       <td mat-cell *matCellDef="let g">{{ g.percent_credit_received }}</td>
     </ng-container>
+    <ng-container matColumnDef="ivrank">
+      <th mat-header-cell *matHeaderCellDef>IV Rank</th>
+      <td mat-cell *matCellDef="let g">{{ g.iv_rank }}</td>
+    </ng-container>
     <ng-container matColumnDef="rules">
       <th mat-header-cell *matHeaderCellDef>Rules</th>
       <td mat-cell *matCellDef="let g">

--- a/ui/src/app/positions/positions-page/positions-page.component.ts
+++ b/ui/src/app/positions/positions-page/positions-page.component.ts
@@ -18,6 +18,7 @@ export class PositionsPageComponent implements OnInit {
     'price',
     'pl',
     'percent',
+    'ivrank',
     'rules',
     'positions',
   ];

--- a/ui/src/app/positions/positions.models.ts
+++ b/ui/src/app/positions/positions.models.ts
@@ -9,6 +9,7 @@ export interface PositionGroup {
   current_group_price: number;
   group_approximate_p_l: number;
   percent_credit_received: number | null;
+  iv_rank?: number | null;
   rules?: import('./positions.rules').RuleResult[];
   positions: Position[];
 }


### PR DESCRIPTION
## Summary
- pull implied volatility data from tastytrade and include `iv_rank` for each position group
- surface `iv_rank` in the UI next to percent credit
- adjust tests for new `iv_rank` field

## Testing
- `pip install -r api/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68509d7acf54832e9118e16bbb66f043