### PR TITLE
Improve journal note preview responsiveness

### DIFF
--- a/ui/src/app/journal/journal-entry-list/journal-entry-list.component.html
+++ b/ui/src/app/journal/journal-entry-list/journal-entry-list.component.html
@@ -16,8 +16,8 @@
           ({{ e.events.length }} {{ e.events.length === 1 ? 'event' : 'events' }})
         </span>
       </mat-panel-title>
-      <mat-panel-description *ngIf="!panel.expanded">
-        {{ e.notes | slice:0:175 }}<span *ngIf="e.notes.length>175">…</span>
+      <mat-panel-description *ngIf="!panel.expanded" class="notes-snippet">
+        {{ e.notes | slice:0:maxSnippetLength }}<span *ngIf="e.notes.length>maxSnippetLength">…</span>
       </mat-panel-description>
     </mat-expansion-panel-header>
 

--- a/ui/src/app/journal/journal-entry-list/journal-entry-list.component.scss
+++ b/ui/src/app/journal/journal-entry-list/journal-entry-list.component.scss
@@ -4,7 +4,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 300px; /* or whatever fits your layout */
+  width: 100%;
 }
 
 

--- a/ui/src/app/journal/journal-entry-list/journal-entry-list.component.ts
+++ b/ui/src/app/journal/journal-entry-list/journal-entry-list.component.ts
@@ -1,5 +1,5 @@
 // src/app/journal-entry-list/journal-entry-list.component.ts
-import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
+import {Component, EventEmitter, Input, OnInit, Output, HostListener} from '@angular/core';
 import { JournalEntry } from '../journal.models';
 
 @Component({
@@ -13,11 +13,24 @@ export class JournalEntryListComponent implements OnInit {
   @Input() entries: JournalEntry[] = [];
   @Output() entrySelected = new EventEmitter<JournalEntry>();
 
+  maxSnippetLength = 175;
+
   onPanelOpen(entry: JournalEntry) {
     this.entrySelected.emit(entry);
   }
 
   ngOnInit(): void {
+    this.updateSnippetLength();
+  }
+
+  @HostListener('window:resize')
+  onResize() {
+    this.updateSnippetLength();
+  }
+
+  private updateSnippetLength() {
+    const width = window.innerWidth;
+    this.maxSnippetLength = Math.min(Math.max(Math.floor(width / 6), 50), 400);
   }
 
   copyEntry(entry: JournalEntry) {


### PR DESCRIPTION
## Summary
- allow the note preview to resize with screen width

## Testing
- `pip install -r api/requirements.txt`
- `pytest -q`
- `npm ci`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6850c12cab0c832e858657178c6a436b