### PR TITLE
Improve journal entry preview length scaling

### DIFF
--- a/ui/src/app/journal/journal-entry-list/journal-entry-list.component.html
+++ b/ui/src/app/journal/journal-entry-list/journal-entry-list.component.html
@@ -17,7 +17,7 @@
         </span>
       </mat-panel-title>
       <mat-panel-description *ngIf="!panel.expanded">
-        {{ e.notes | slice:0:175 }}<span *ngIf="e.notes.length>175">…</span>
+        {{ e.notes | slice:0:charLimit }}<span *ngIf="e.notes.length>charLimit">…</span>
       </mat-panel-description>
     </mat-expansion-panel-header>
 

--- a/ui/src/app/journal/journal-entry-list/journal-entry-list.component.ts
+++ b/ui/src/app/journal/journal-entry-list/journal-entry-list.component.ts
@@ -1,5 +1,5 @@
 // src/app/journal-entry-list/journal-entry-list.component.ts
-import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
+import {Component, EventEmitter, HostListener, Input, OnInit, Output} from '@angular/core';
 import { JournalEntry } from '../journal.models';
 
 @Component({
@@ -13,11 +13,30 @@ export class JournalEntryListComponent implements OnInit {
   @Input() entries: JournalEntry[] = [];
   @Output() entrySelected = new EventEmitter<JournalEntry>();
 
+  charLimit = 175;
+
   onPanelOpen(entry: JournalEntry) {
     this.entrySelected.emit(entry);
   }
 
   ngOnInit(): void {
+    this.updateCharLimit(window.innerWidth);
+  }
+
+  @HostListener('window:resize', ['$event'])
+  onResize(event: Event) {
+    const w = (event.target as Window).innerWidth;
+    this.updateCharLimit(w);
+  }
+
+  private updateCharLimit(width: number) {
+    if (width < 600) {
+      this.charLimit = 80;
+    } else if (width < 960) {
+      this.charLimit = 120;
+    } else {
+      this.charLimit = 175;
+    }
   }
 
   copyEntry(entry: JournalEntry) {


### PR DESCRIPTION
## Summary
- adjust journal entry preview length by screen width
- use HostListener to update on resize

## Testing
- `pytest`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6850c12cab0c832e858657178c6a436b