### PR TITLE
Add dashboard landing page

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -14,8 +14,8 @@ const routes: Routes = [
   },
   {
     path: '',
-    redirectTo: 'journal',
-    pathMatch: 'full'
+    loadChildren: () =>
+      import('./dashboard/dashboard.module').then(m => m.DashboardModule)
   },
   // future feature modules here...
 ];

--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -13,10 +13,15 @@ const routes: Routes = [
       import('./positions/positions.module').then(m => m.PositionsModule)
   },
   {
-    path: '',
+    path: 'dashboard',
     loadChildren: () =>
       import('./dashboard/dashboard.module').then(m => m.DashboardModule)
   },
+  {
+    path: '',
+    redirectTo: '/dashboard',
+    pathMatch: 'full'
+  }
   // future feature modules here...
 ];
 

--- a/ui/src/app/app.component.html
+++ b/ui/src/app/app.component.html
@@ -12,7 +12,7 @@
 <mat-sidenav-container class="full-height">
   <mat-sidenav #sidenav mode="side" opened class="app-sidenav">
     <mat-nav-list>
-      <a mat-list-item routerLink="/" routerLinkActive="active-link" (click)="sidenav.close()">Dashboard</a>
+      <a mat-list-item routerLink="/dashboard" routerLinkActive="active-link" (click)="sidenav.close()">Dashboard</a>
       <a mat-list-item routerLink="/journal" routerLinkActive="active-link" (click)="sidenav.close()">Journal</a>
       <a mat-list-item routerLink="/positions" routerLinkActive="active-link" (click)="sidenav.close()">Positions</a>
       <!-- future nav items -->

--- a/ui/src/app/app.component.html
+++ b/ui/src/app/app.component.html
@@ -12,6 +12,7 @@
 <mat-sidenav-container class="full-height">
   <mat-sidenav #sidenav mode="side" opened class="app-sidenav">
     <mat-nav-list>
+      <a mat-list-item routerLink="/" routerLinkActive="active-link" (click)="sidenav.close()">Dashboard</a>
       <a mat-list-item routerLink="/journal" routerLinkActive="active-link" (click)="sidenav.close()">Journal</a>
       <a mat-list-item routerLink="/positions" routerLinkActive="active-link" (click)="sidenav.close()">Positions</a>
       <!-- future nav items -->

--- a/ui/src/app/dashboard/dashboard-data.ts
+++ b/ui/src/app/dashboard/dashboard-data.ts
@@ -3,13 +3,31 @@ export interface ResourceLink {
   url: string;
 }
 
-export const guidelines: string[] = [
+export const tradeGuidelines: string[] = [
   'Look at a daily chart',
   'Look at SP equity hub',
+  'Follow the tastytrade rules',
+  'If you break the rules, risk defined',
+  'If you are before the trend, accept the risk, or risk define',
   'If a trade keeps you up at night, get out!'
 ];
 
+export const dailyGuidelines: string[] = [
+  'Read the SpotGamma Founders Note',
+  'Look at any news that may impact the market',
+  'Look at spotgamma dashboard',
+  'Look at TradingView ES1!',
+  'Look at the SpotGamma Tools',
+  'Has the marco environment changed?',
+  'Open Tastytrade and look over the trades you have on',
+];
+
 export const resources: ResourceLink[] = [
+  { name: 'SpotGamma Founders Notes', url: 'https://dashboard.spotgamma.com/foundersNotes' },
+  { name: 'SpotGamma Dashboard', url: 'https://dashboard.spotgamma.com/home?eh-model=legacy' },
   { name: 'TradingView ES1!', url: 'https://www.tradingview.com/chart/HJq2QPjq/?symbol=CME_MINI%3AES1%21' },
-  { name: 'SpotGamma Dashboard', url: 'https://dashboard.spotgamma.com/home?eh-model=legacy' }
+  { name: 'Market News', url: 'https://www.forexfactory.com/calendar'},
+  { name: 'Financial Juice', url: 'https://www.financialjuice.com/' },
+  { name: 'SG Equity Hub', url: 'https://dashboard.spotgamma.com/equityhub?sym=SPX&eh-model=synthoi' },
+  { name: 'SG Scanners', url: 'https://dashboard.spotgamma.com/scanners?eh-model=legacy' },
 ];

--- a/ui/src/app/dashboard/dashboard-data.ts
+++ b/ui/src/app/dashboard/dashboard-data.ts
@@ -1,0 +1,15 @@
+export interface ResourceLink {
+  name: string;
+  url: string;
+}
+
+export const guidelines: string[] = [
+  'Look at a daily chart',
+  'Look at SP equity hub',
+  'If a trade keeps you up at night, get out!'
+];
+
+export const resources: ResourceLink[] = [
+  { name: 'TradingView ES1!', url: 'https://www.tradingview.com/chart/HJq2QPjq/?symbol=CME_MINI%3AES1%21' },
+  { name: 'SpotGamma Dashboard', url: 'https://dashboard.spotgamma.com/home?eh-model=legacy' }
+];

--- a/ui/src/app/dashboard/dashboard-page/dashboard-page.component.html
+++ b/ui/src/app/dashboard/dashboard-page/dashboard-page.component.html
@@ -1,0 +1,17 @@
+<div class="dashboard">
+  <section class="guidelines">
+    <h2>Daily Trading Guidelines</h2>
+    <ul>
+      <li *ngFor="let rule of guidelines">{{ rule }}</li>
+    </ul>
+  </section>
+
+  <section class="resources">
+    <h2>Analysis Links</h2>
+    <ul>
+      <li *ngFor="let r of resources">
+        <a [href]="r.url" target="_blank" rel="noopener">{{ r.name }}</a>
+      </li>
+    </ul>
+  </section>
+</div>

--- a/ui/src/app/dashboard/dashboard-page/dashboard-page.component.html
+++ b/ui/src/app/dashboard/dashboard-page/dashboard-page.component.html
@@ -1,8 +1,8 @@
 <div class="dashboard">
   <section class="guidelines">
-    <h2>Daily Trading Guidelines</h2>
+    <h2>Daily Guidelines</h2>
     <ul>
-      <li *ngFor="let rule of guidelines">{{ rule }}</li>
+      <li *ngFor="let rule of dailyGuidelines">{{ rule }}</li>
     </ul>
   </section>
 
@@ -12,6 +12,12 @@
       <li *ngFor="let r of resources">
         <a [href]="r.url" target="_blank" rel="noopener">{{ r.name }}</a>
       </li>
+    </ul>
+  </section>
+  <section class="guidelines">
+    <h2>Daily Trading Guidelines</h2>
+    <ul>
+      <li *ngFor="let rule of tradeGuidelines">{{ rule }}</li>
     </ul>
   </section>
 </div>

--- a/ui/src/app/dashboard/dashboard-page/dashboard-page.component.scss
+++ b/ui/src/app/dashboard/dashboard-page/dashboard-page.component.scss
@@ -5,3 +5,12 @@
 section h2 {
   margin-top: 0;
 }
+
+.dashboard {
+  display: flex;
+  padding: 1rem;
+
+  > section {
+    flex: 1;
+  }
+}

--- a/ui/src/app/dashboard/dashboard-page/dashboard-page.component.scss
+++ b/ui/src/app/dashboard/dashboard-page/dashboard-page.component.scss
@@ -1,0 +1,7 @@
+.dashboard {
+  padding: 1rem;
+}
+
+section h2 {
+  margin-top: 0;
+}

--- a/ui/src/app/dashboard/dashboard-page/dashboard-page.component.spec.ts
+++ b/ui/src/app/dashboard/dashboard-page/dashboard-page.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { DashboardPageComponent } from './dashboard-page.component';
+import { guidelines, resources } from '../dashboard-data';
+
+describe('DashboardPageComponent', () => {
+  let component: DashboardPageComponent;
+  let fixture: ComponentFixture<DashboardPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [DashboardPageComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DashboardPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should expose guidelines and resources', () => {
+    expect(component.guidelines).toBe(guidelines);
+    expect(component.resources).toBe(resources);
+  });
+});

--- a/ui/src/app/dashboard/dashboard-page/dashboard-page.component.ts
+++ b/ui/src/app/dashboard/dashboard-page/dashboard-page.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { guidelines, resources, ResourceLink } from '../dashboard-data';
+
+@Component({
+  selector: 'app-dashboard-page',
+  templateUrl: './dashboard-page.component.html',
+  styleUrls: ['./dashboard-page.component.scss'],
+  standalone: false,
+})
+export class DashboardPageComponent {
+  guidelines = guidelines;
+  resources: ResourceLink[] = resources;
+}

--- a/ui/src/app/dashboard/dashboard-page/dashboard-page.component.ts
+++ b/ui/src/app/dashboard/dashboard-page/dashboard-page.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { guidelines, resources, ResourceLink } from '../dashboard-data';
+import {resources, ResourceLink, dailyGuidelines, tradeGuidelines} from '../dashboard-data';
 
 @Component({
   selector: 'app-dashboard-page',
@@ -8,6 +8,7 @@ import { guidelines, resources, ResourceLink } from '../dashboard-data';
   standalone: false,
 })
 export class DashboardPageComponent {
-  guidelines = guidelines;
   resources: ResourceLink[] = resources;
+  protected readonly dailyGuidelines = dailyGuidelines;
+  protected readonly tradeGuidelines = tradeGuidelines;
 }

--- a/ui/src/app/dashboard/dashboard-routing.module.ts
+++ b/ui/src/app/dashboard/dashboard-routing.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { DashboardPageComponent } from './dashboard-page/dashboard-page.component';
+
+const routes: Routes = [
+  { path: '', component: DashboardPageComponent }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class DashboardRoutingModule {}

--- a/ui/src/app/dashboard/dashboard.module.ts
+++ b/ui/src/app/dashboard/dashboard.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SharedMaterialModule } from '../shared/material.module';
+import { DashboardRoutingModule } from './dashboard-routing.module';
+import { DashboardPageComponent } from './dashboard-page/dashboard-page.component';
+
+@NgModule({
+  declarations: [DashboardPageComponent],
+  imports: [CommonModule, SharedMaterialModule, DashboardRoutingModule],
+})
+export class DashboardModule {}


### PR DESCRIPTION
## Summary
- add dashboard module for landing page with static guidelines and resource links
- load the new dashboard at root route and add nav item
- include simple unit test for the dashboard component

## Testing
- `pip install -r api/requirements.txt`
- `pytest`
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6850f12c6294832e92ed097be7df646e