### PR TITLE
Update dashboard resource links

### DIFF
--- a/ui/src/app/dashboard/dashboard-data.ts
+++ b/ui/src/app/dashboard/dashboard-data.ts
@@ -22,14 +22,17 @@ export const dailyGuidelines: string[] = [
   'Open Tastytrade and look over the trades you have on',
 ];
 
-export const resources: ResourceLink[] = [
+export const dailyOverviewAnalysis: ResourceLink[] = [
   { name: 'SpotGamma Founders Notes', url: 'https://dashboard.spotgamma.com/foundersNotes' },
   { name: 'TradingView ES1!', url: 'https://www.tradingview.com/chart/HJq2QPjq/?symbol=CME_MINI%3AES1%21' },
-  { name: 'Market News', url: 'https://www.forexfactory.com/calendar'},
+  { name: 'Market News', url: 'https://www.forexfactory.com/calendar' },
   { name: 'Financial Juice', url: 'https://www.financialjuice.com/' },
+];
+
+export const spotGammaToolLinks: ResourceLink[] = [
   { name: 'SpotGamma Dashboard', url: 'https://dashboard.spotgamma.com/home?eh-model=legacy' },
   { name: 'SpotGamma Trace', url: 'https://dashboard.spotgamma.com/trace?lense=1&traceSym=SPX' },
-  { name: 'SpotGamma Hero', url: 'https://dashboard.spotgamma.com/hiro?eh-model=legacy'},
+  { name: 'SpotGamma Hero', url: 'https://dashboard.spotgamma.com/hiro?eh-model=legacy' },
   { name: 'SG Equity Hub', url: 'https://dashboard.spotgamma.com/equityhub?sym=SPX&eh-model=synthoi' },
   { name: 'SG Scanners', url: 'https://dashboard.spotgamma.com/scanners?eh-model=legacy' },
 ];

--- a/ui/src/app/dashboard/dashboard-page/dashboard-page.component.html
+++ b/ui/src/app/dashboard/dashboard-page/dashboard-page.component.html
@@ -7,9 +7,20 @@
   </section>
 
   <section class="resources">
-    <h2>Analysis Links</h2>
+    <h2>Daily Overview Analysis</h2>
+    <button mat-raised-button color="primary" (click)="openAll(dailyOverview)">Open All</button>
     <ul>
-      <li *ngFor="let r of resources">
+      <li *ngFor="let r of dailyOverview">
+        <a [href]="r.url" target="_blank" rel="noopener">{{ r.name }}</a>
+      </li>
+    </ul>
+  </section>
+
+  <section class="resources">
+    <h2>SpotGamma Tools</h2>
+    <button mat-raised-button color="primary" (click)="openAll(spotGammaTools)">Open All</button>
+    <ul>
+      <li *ngFor="let r of spotGammaTools">
         <a [href]="r.url" target="_blank" rel="noopener">{{ r.name }}</a>
       </li>
     </ul>

--- a/ui/src/app/dashboard/dashboard-page/dashboard-page.component.spec.ts
+++ b/ui/src/app/dashboard/dashboard-page/dashboard-page.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { DashboardPageComponent } from './dashboard-page.component';
-import { guidelines, resources } from '../dashboard-data';
+import { dailyOverviewAnalysis, spotGammaToolLinks, dailyGuidelines, tradeGuidelines } from '../dashboard-data';
 
 describe('DashboardPageComponent', () => {
   let component: DashboardPageComponent;
@@ -18,8 +18,10 @@ describe('DashboardPageComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should expose guidelines and resources', () => {
-    expect(component.guidelines).toBe(guidelines);
-    expect(component.resources).toBe(resources);
+  it('should expose links and guidelines', () => {
+    expect(component.dailyOverview).toBe(dailyOverviewAnalysis);
+    expect(component.spotGammaTools).toBe(spotGammaToolLinks);
+    expect(component.dailyGuidelines).toBe(dailyGuidelines);
+    expect(component.tradeGuidelines).toBe(tradeGuidelines);
   });
 });

--- a/ui/src/app/dashboard/dashboard-page/dashboard-page.component.ts
+++ b/ui/src/app/dashboard/dashboard-page/dashboard-page.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import {resources, ResourceLink, dailyGuidelines, tradeGuidelines} from '../dashboard-data';
+import {dailyOverviewAnalysis, spotGammaToolLinks, ResourceLink, dailyGuidelines, tradeGuidelines} from '../dashboard-data';
 
 @Component({
   selector: 'app-dashboard-page',
@@ -8,7 +8,12 @@ import {resources, ResourceLink, dailyGuidelines, tradeGuidelines} from '../dash
   standalone: false,
 })
 export class DashboardPageComponent {
-  resources: ResourceLink[] = resources;
-  protected readonly dailyGuidelines = dailyGuidelines;
-  protected readonly tradeGuidelines = tradeGuidelines;
+  dailyOverview: ResourceLink[] = dailyOverviewAnalysis;
+  spotGammaTools: ResourceLink[] = spotGammaToolLinks;
+  readonly dailyGuidelines = dailyGuidelines;
+  readonly tradeGuidelines = tradeGuidelines;
+
+  openAll(links: ResourceLink[]): void {
+    links.forEach(link => window.open(link.url, '_blank'));
+  }
 }


### PR DESCRIPTION
## Summary
- split analysis links into daily overview and SpotGamma tools
- add open-all buttons for each set of links
- adjust dashboard tests for new properties

## Testing
- `npm install`
- `npm test` *(fails: positions.rules.spec.ts expected id `low iv rank` to equal `14 iv rank`)*

------
https://chatgpt.com/codex/tasks/task_e_6851fe30a2b8832e816aae5577cecc35