### PR TITLE
Add per-position delta display

### DIFF
--- a/api/app/routers/v1/trades.py
+++ b/api/app/routers/v1/trades.py
@@ -191,7 +191,12 @@ def get_all_positions(db: Session = Depends(get_db)):
             else:
                 percent_credit_received = None
 
-            total_delta = round(delta_sum_unrounded * 100, 2)
+            # total delta should be expressed as the sum of individual option
+            # deltas without any additional scaling. Each position's delta is
+            # already reported as a decimal value (e.g. 0.5 for 50 deltas), so
+            # we simply sum the computed deltas for the group and round to two
+            # decimals.
+            total_delta = round(delta_sum_unrounded, 2)
 
             groups_list.append({
                 "underlying_symbol": underlying,

--- a/ui/src/app/positions/positions-page/positions-page.component.html
+++ b/ui/src/app/positions/positions-page/positions-page.component.html
@@ -65,6 +65,10 @@
               <th mat-header-cell *matHeaderCellDef>P/L</th>
               <td mat-cell *matCellDef="let p">{{ p['approximate-p-l'] }}</td>
             </ng-container>
+            <ng-container matColumnDef="cdelta">
+              <th mat-header-cell *matHeaderCellDef>Delta</th>
+              <td mat-cell *matCellDef="let p">{{ p['market_data']?.computed_delta }}</td>
+            </ng-container>
             <tr mat-header-row *matHeaderRowDef="positionCols"></tr>
             <tr mat-row *matRowDef="let row; columns: positionCols"></tr>
           </table>

--- a/ui/src/app/positions/positions-page/positions-page.component.ts
+++ b/ui/src/app/positions/positions-page/positions-page.component.ts
@@ -24,7 +24,7 @@ export class PositionsPageComponent implements OnInit {
     'positions',
   ];
 
-  positionCols = ['symbol', 'qty', 'type', 'plpos'];
+  positionCols = ['symbol', 'qty', 'type', 'plpos', 'cdelta'];
 
   constructor(private api: PositionsApiService) {}
 


### PR DESCRIPTION
## Summary
- fix delta calculation when grouping positions
- add computed delta column for each position on positions page

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68563d675ab8832e9dff8aea295470db