### PR TITLE
Remove grouped P/L column

### DIFF
--- a/api/app/routers/v1/trades.py
+++ b/api/app/routers/v1/trades.py
@@ -31,9 +31,8 @@ def get_all_positions(db: Session = Depends(get_db)):
       2. Group by 'underlying-symbol' and 'expires-at'.
       3. For each group, compute:
          - total_credit_received using the quantity direction sign and group multiplier
-         - current_group_price as the sum of the positions' approximate P/L values
-         - group_approximate_p_l = total_credit_received - current_group_price (rounded to 2 decimals)
-         - percent_credit_received = int((group_approximate_p_l / total_credit_received) * 100), or None
+        - current_group_price as the sum of the positions' approximate P/L values
+        - percent_credit_received = int((current_group_price / total_credit_received) * 100), or None
     """
     try:
         token = tastytrade.get_active_token(db)
@@ -201,8 +200,6 @@ def get_all_positions(db: Session = Depends(get_db)):
 
             total_credit_received = round(total_credit_unrounded * multiplier, 2)
             current_group_price = round(current_price_unrounded, 2)
-            group_pl = round(total_credit_received - current_group_price, 2)
-
             if total_credit_received != 0:
                 percent_credit_received = int((current_group_price / total_credit_received) * 100)
             else:
@@ -220,7 +217,6 @@ def get_all_positions(db: Session = Depends(get_db)):
                 "expires_at": expires,
                 "total_credit_received": total_credit_received,
                 "current_group_price": current_group_price,
-                "group_approximate_p_l": group_pl,
                 "percent_credit_received": percent_credit_received,
                 "total_delta": total_delta,
                 "positions": plist,

--- a/api/app/schema.py
+++ b/api/app/schema.py
@@ -105,7 +105,6 @@ class GroupedPositions(BaseModel):
     expires_at: str
     total_credit_received: float
     current_group_price: float
-    group_approximate_p_l: float
     percent_credit_received: Optional[int] = None
     total_delta: Optional[float] = None
     iv_rank: Optional[float] = Field(None, alias="iv_rank")

--- a/api/tests/test_trades_v1.py
+++ b/api/tests/test_trades_v1.py
@@ -91,7 +91,6 @@ async def test_trades_grouped(client, monkeypatch):
                         "expires_at": "2024-01-19",
                         "total_credit_received": 350.0,
                         "current_group_price": -2550.0,
-                        "group_approximate_p_l": 2900.0,
                         "percent_credit_received": -728,
                         "total_delta": -1.0,
                         "iv_rank": 19.1,

--- a/ui/src/app/positions/positions-page/positions-page.component.html
+++ b/ui/src/app/positions/positions-page/positions-page.component.html
@@ -17,10 +17,6 @@
       <th mat-header-cell *matHeaderCellDef>Current Price</th>
       <td mat-cell *matCellDef="let g">{{ g.current_group_price }}</td>
     </ng-container>
-    <ng-container matColumnDef="pl">
-      <th mat-header-cell *matHeaderCellDef>P/L</th>
-      <td mat-cell *matCellDef="let g">{{ g.group_approximate_p_l }}</td>
-    </ng-container>
     <ng-container matColumnDef="percent">
       <th mat-header-cell *matHeaderCellDef>% Credit</th>
       <td mat-cell *matCellDef="let g">{{ g.percent_credit_received }}</td>

--- a/ui/src/app/positions/positions-page/positions-page.component.spec.ts
+++ b/ui/src/app/positions/positions-page/positions-page.component.spec.ts
@@ -36,7 +36,6 @@ describe('PositionsPageComponent', () => {
       expires_at: '2025-01-15',
       total_credit_received: 10,
       current_group_price: 5,
-      group_approximate_p_l: 5,
       percent_credit_received: 55,
       total_delta: 0,
       positions: []
@@ -55,7 +54,6 @@ describe('PositionsPageComponent', () => {
       expires_at: '',
       total_credit_received: 0,
       current_group_price: 0,
-      group_approximate_p_l: 0,
       percent_credit_received: null,
       total_delta: 0,
       positions: [],

--- a/ui/src/app/positions/positions-page/positions-page.component.ts
+++ b/ui/src/app/positions/positions-page/positions-page.component.ts
@@ -16,7 +16,6 @@ export class PositionsPageComponent implements OnInit {
     'expires',
     'credit',
     'price',
-    'pl',
     'percent',
     'delta',
     'ivrank',

--- a/ui/src/app/positions/positions.models.ts
+++ b/ui/src/app/positions/positions.models.ts
@@ -7,7 +7,6 @@ export interface PositionGroup {
   expires_at: string;
   total_credit_received: number;
   current_group_price: number;
-  group_approximate_p_l: number;
   percent_credit_received: number | null;
   total_delta?: number | null;
   iv_rank?: number | null;

--- a/ui/src/app/positions/positions.rules.spec.ts
+++ b/ui/src/app/positions/positions.rules.spec.ts
@@ -7,7 +7,6 @@ function makeGroup(overrides: Partial<PositionGroup> = {}): PositionGroup {
     expires_at: '2025-01-10',
     total_credit_received: 10,
     current_group_price: 5,
-    group_approximate_p_l: 5,
     percent_credit_received: 50,
     total_delta: 0,
     positions: [],
@@ -30,7 +29,7 @@ describe('positions rules', () => {
   });
 
   it('profitRule calculates percent when not provided', () => {
-    const g = makeGroup({ percent_credit_received: null, group_approximate_p_l: 4, total_credit_received: 10 });
+    const g = makeGroup({ percent_credit_received: null, current_group_price: 6, total_credit_received: 10 });
     expect(profitRule(g)).toEqual({ id: '50% profit', level: 'warning' });
   });
 
@@ -42,7 +41,7 @@ describe('positions rules', () => {
   it('lossRule calculates percent when not provided', () => {
     const g = makeGroup({
       percent_credit_received: null,
-      group_approximate_p_l: -15,
+      current_group_price: 25,
       total_credit_received: 10
     });
     expect(lossRule(g)).toEqual({ id: '2x loss', level: 'warning' });

--- a/ui/src/app/positions/positions.rules.ts
+++ b/ui/src/app/positions/positions.rules.ts
@@ -38,7 +38,7 @@ export const profitRule: Rule = g => {
   const total = g.total_credit_received;
   let pct = g.percent_credit_received;
   if (pct === null || pct === undefined) {
-    pct = total ? Math.round((g.group_approximate_p_l / total) * 100) : 0;
+    pct = total ? Math.round(((total - g.current_group_price) / total) * 100) : 0;
   }
 
   if (pct >= 50) {
@@ -54,7 +54,7 @@ export const lossRule: Rule = g => {
   const total = g.total_credit_received;
   let pct = g.percent_credit_received;
   if (pct === null || pct === undefined) {
-    pct = total ? Math.round((g.group_approximate_p_l / total) * 100) : 0;
+    pct = total ? Math.round(((total - g.current_group_price) / total) * 100) : 0;
   }
 
   if (pct <= -150) {


### PR DESCRIPTION
## Summary
- drop `group_approximate_p_l` from API models and responses
- remove grouped P/L column from the Angular UI
- adjust rules and specs to use `current_group_price`

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685650fba358832e95fafbf4f50d1a41