### PR TITLE
Rename group price variable

### DIFF
--- a/api/app/routers/v1/trades.py
+++ b/api/app/routers/v1/trades.py
@@ -31,8 +31,8 @@ def get_all_positions(db: Session = Depends(get_db)):
       2. Group by 'underlying-symbol' and 'expires-at'.
       3. For each group, compute:
          - total_credit_received using the quantity direction sign and group multiplier
-        - current_group_price as the sum of the positions' approximate P/L values
-        - percent_credit_received = int((current_group_price / total_credit_received) * 100), or None
+        - current_group_p_l as the sum of the positions' approximate P/L values
+        - percent_credit_received = int((current_group_p_l / total_credit_received) * 100), or None
     """
     try:
         token = tastytrade.get_active_token(db)
@@ -199,9 +199,9 @@ def get_all_positions(db: Session = Depends(get_db)):
                     pass
 
             total_credit_received = round(total_credit_unrounded * multiplier, 2)
-            current_group_price = round(current_price_unrounded, 2)
+            current_group_p_l = round(current_price_unrounded, 2)
             if total_credit_received != 0:
-                percent_credit_received = int((current_group_price / total_credit_received) * 100)
+                percent_credit_received = int((current_group_p_l / total_credit_received) * 100)
             else:
                 percent_credit_received = None
 
@@ -216,7 +216,7 @@ def get_all_positions(db: Session = Depends(get_db)):
                 "underlying_symbol": underlying,
                 "expires_at": expires,
                 "total_credit_received": total_credit_received,
-                "current_group_price": current_group_price,
+                "current_group_p_l": current_group_p_l,
                 "percent_credit_received": percent_credit_received,
                 "total_delta": total_delta,
                 "positions": plist,

--- a/api/app/schema.py
+++ b/api/app/schema.py
@@ -104,7 +104,7 @@ class GroupedPositions(BaseModel):
     underlying_symbol: str
     expires_at: str
     total_credit_received: float
-    current_group_price: float
+    current_group_p_l: float
     percent_credit_received: Optional[int] = None
     total_delta: Optional[float] = None
     iv_rank: Optional[float] = Field(None, alias="iv_rank")

--- a/api/tests/test_trades_v1.py
+++ b/api/tests/test_trades_v1.py
@@ -90,7 +90,7 @@ async def test_trades_grouped(client, monkeypatch):
                         "underlying_symbol": "SPY",
                         "expires_at": "2024-01-19",
                         "total_credit_received": 350.0,
-                        "current_group_price": -2550.0,
+                        "current_group_p_l": -2550.0,
                         "percent_credit_received": -728,
                         "total_delta": -1.0,
                         "iv_rank": 19.1,

--- a/ui/src/app/positions/positions-page/positions-page.component.html
+++ b/ui/src/app/positions/positions-page/positions-page.component.html
@@ -14,8 +14,8 @@
       <td mat-cell *matCellDef="let g">{{ g.total_credit_received }}</td>
     </ng-container>
     <ng-container matColumnDef="price">
-      <th mat-header-cell *matHeaderCellDef>Current Price</th>
-      <td mat-cell *matCellDef="let g">{{ g.current_group_price }}</td>
+      <th mat-header-cell *matHeaderCellDef>P/L</th>
+      <td mat-cell *matCellDef="let g">{{ g.current_group_p_l }}</td>
     </ng-container>
     <ng-container matColumnDef="percent">
       <th mat-header-cell *matHeaderCellDef>% Credit</th>

--- a/ui/src/app/positions/positions-page/positions-page.component.spec.ts
+++ b/ui/src/app/positions/positions-page/positions-page.component.spec.ts
@@ -35,7 +35,7 @@ describe('PositionsPageComponent', () => {
       underlying_symbol: 'SPY',
       expires_at: '2025-01-15',
       total_credit_received: 10,
-      current_group_price: 5,
+      current_group_p_l: 5,
       percent_credit_received: 55,
       total_delta: 0,
       positions: []
@@ -53,7 +53,7 @@ describe('PositionsPageComponent', () => {
       underlying_symbol: '',
       expires_at: '',
       total_credit_received: 0,
-      current_group_price: 0,
+      current_group_p_l: 0,
       percent_credit_received: null,
       total_delta: 0,
       positions: [],

--- a/ui/src/app/positions/positions.models.ts
+++ b/ui/src/app/positions/positions.models.ts
@@ -6,7 +6,7 @@ export interface PositionGroup {
   underlying_symbol: string;
   expires_at: string;
   total_credit_received: number;
-  current_group_price: number;
+  current_group_p_l: number;
   percent_credit_received: number | null;
   total_delta?: number | null;
   iv_rank?: number | null;

--- a/ui/src/app/positions/positions.rules.spec.ts
+++ b/ui/src/app/positions/positions.rules.spec.ts
@@ -6,7 +6,7 @@ function makeGroup(overrides: Partial<PositionGroup> = {}): PositionGroup {
     underlying_symbol: 'SPY',
     expires_at: '2025-01-10',
     total_credit_received: 10,
-    current_group_price: 5,
+    current_group_p_l: 5,
     percent_credit_received: 50,
     total_delta: 0,
     positions: [],
@@ -29,7 +29,7 @@ describe('positions rules', () => {
   });
 
   it('profitRule calculates percent when not provided', () => {
-    const g = makeGroup({ percent_credit_received: null, current_group_price: 6, total_credit_received: 10 });
+    const g = makeGroup({ percent_credit_received: null, current_group_p_l: 6, total_credit_received: 10 });
     expect(profitRule(g)).toEqual({ id: '50% profit', level: 'warning' });
   });
 
@@ -41,7 +41,7 @@ describe('positions rules', () => {
   it('lossRule calculates percent when not provided', () => {
     const g = makeGroup({
       percent_credit_received: null,
-      current_group_price: 25,
+      current_group_p_l: 25,
       total_credit_received: 10
     });
     expect(lossRule(g)).toEqual({ id: '2x loss', level: 'warning' });

--- a/ui/src/app/positions/positions.rules.ts
+++ b/ui/src/app/positions/positions.rules.ts
@@ -38,7 +38,7 @@ export const profitRule: Rule = g => {
   const total = g.total_credit_received;
   let pct = g.percent_credit_received;
   if (pct === null || pct === undefined) {
-    pct = total ? Math.round(((total - g.current_group_price) / total) * 100) : 0;
+    pct = total ? Math.round(((total - g.current_group_p_l) / total) * 100) : 0;
   }
 
   if (pct >= 50) {
@@ -54,7 +54,7 @@ export const lossRule: Rule = g => {
   const total = g.total_credit_received;
   let pct = g.percent_credit_received;
   if (pct === null || pct === undefined) {
-    pct = total ? Math.round(((total - g.current_group_price) / total) * 100) : 0;
+    pct = total ? Math.round(((total - g.current_group_p_l) / total) * 100) : 0;
   }
 
   if (pct <= -150) {


### PR DESCRIPTION
## Summary
- rename `current_group_price` to `current_group_p_l`
- update Angular label from `Current Price` to `P/L`
- adjust backend schema, API, and tests

## Testing
- `pytest -q`
- `npm test -- --watch=false`

------
https://chatgpt.com/codex/tasks/task_e_68570729c2bc832e900fee161099b276