### PR TITLE
Format position metrics

### DIFF
--- a/api/app/routers/v1/trades.py
+++ b/api/app/routers/v1/trades.py
@@ -132,7 +132,7 @@ def get_all_positions(db: Session = Depends(get_db)):
                             sign = 1 if qty_dir == "Short" else -1
                         else:
                             sign = 1
-                        md_item["computed_delta"] = sign * delta_float
+                        md_item["computed_delta"] = round(sign * delta_float, 2)
             else:
                 md_item = {}
 
@@ -156,7 +156,7 @@ def get_all_positions(db: Session = Depends(get_db)):
                 else:
                     approximate_pl = (avg_open - mark) * quantity * multiplier
 
-            p["approximate-p-l"] = approximate_pl
+            p["approximate-p-l"] = round(approximate_pl, 2)
 
         grouping: Dict[Tuple[str, str], List[Dict]] = defaultdict(list)
         for p in pos_list:

--- a/ui/src/app/positions/positions-page/positions-page.component.html
+++ b/ui/src/app/positions/positions-page/positions-page.component.html
@@ -7,7 +7,7 @@
     </ng-container>
     <ng-container matColumnDef="expires">
       <th mat-header-cell *matHeaderCellDef>Expires</th>
-      <td mat-cell *matCellDef="let g">{{ g.expires_at }}</td>
+      <td mat-cell *matCellDef="let g">{{ g.expires_at | date:'mediumDate' }}</td>
     </ng-container>
     <ng-container matColumnDef="credit">
       <th mat-header-cell *matHeaderCellDef>Total Credit</th>


### PR DESCRIPTION
## Summary
- round delta and P/L values per position on backend
- show expiration date in a friendly way on the positions page

## Testing
- `pytest -q`
- `npm test --silent -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68570cedd1d8832ebc03859d90516de8