### PR TITLE
Add beta to positions and group totals

### DIFF
--- a/api/app/routers/v1/trades.py
+++ b/api/app/routers/v1/trades.py
@@ -190,6 +190,9 @@ def get_all_positions(db: Session = Depends(get_db)):
                     approximate_pl = (avg_open - mark) * quantity * multiplier
 
             p["approximate-p-l"] = round(approximate_pl, 2)
+            underlying_sym = p.get("underlying-symbol")
+            if underlying_sym in beta_map:
+                p["beta"] = beta_map[underlying_sym]
 
         grouping: Dict[Tuple[str, str], List[Dict]] = defaultdict(list)
         for p in pos_list:
@@ -246,8 +249,10 @@ def get_all_positions(db: Session = Depends(get_db)):
             total_delta = round(delta_sum_unrounded, 2)
 
             beta_val = beta_map.get(underlying)
+            beta_delta = None
             if beta_val is not None:
-                account_beta_delta += beta_val * total_delta
+                beta_delta = round(beta_val * total_delta, 2)
+                account_beta_delta += beta_delta
 
             groups_list.append({
                 "underlying_symbol": underlying,
@@ -256,6 +261,7 @@ def get_all_positions(db: Session = Depends(get_db)):
                 "current_group_p_l": current_group_p_l,
                 "percent_credit_received": percent_credit_received,
                 "total_delta": total_delta,
+                "beta_delta": beta_delta,
                 "positions": plist,
             })
 

--- a/api/app/schema.py
+++ b/api/app/schema.py
@@ -92,6 +92,7 @@ class Position(BaseModel):
     """Generic position data with arbitrary fields."""
 
     approximate_p_l: Optional[float] = Field(None, alias="approximate-p-l")
+    beta: Optional[float] = None
 
     model_config = {
         "populate_by_name": True,
@@ -107,6 +108,7 @@ class GroupedPositions(BaseModel):
     current_group_p_l: float
     percent_credit_received: Optional[int] = None
     total_delta: Optional[float] = None
+    beta_delta: Optional[float] = None
     iv_rank: Optional[float] = Field(None, alias="iv_rank")
     positions: List[Position]
 

--- a/api/tests/test_trades_v1.py
+++ b/api/tests/test_trades_v1.py
@@ -99,6 +99,7 @@ async def test_trades_grouped(client, monkeypatch):
                         "current_group_p_l": -2550.0,
                         "percent_credit_received": -728,
                         "total_delta": -1.0,
+                        "beta_delta": -1.2,
                         "iv_rank": 19.1,
                         "positions": [
                             {
@@ -114,6 +115,7 @@ async def test_trades_grouped(client, monkeypatch):
                                 "quantity-direction": "Short",
                                 "multiplier": "100",
                                 "approximate-p-l": -750.0,
+                                "beta": 1.2,
                                 "market_data": {
                                     "symbol": "SPY_C",
                                     "mark": "10",
@@ -135,6 +137,7 @@ async def test_trades_grouped(client, monkeypatch):
                                 "quantity-direction": "Short",
                                 "multiplier": "100",
                                 "approximate-p-l": -1800.0,
+                                "beta": 1.2,
                                 "market_data": {
                                     "symbol": "SPY_C",
                                     "mark": "10",
@@ -397,5 +400,9 @@ async def test_total_beta_delta(client, monkeypatch):
     resp = await client.get("/v1/trades")
     assert resp.status_code == 200
     acct = resp.json()["accounts"][0]
-    assert acct["total_beta_delta"] == -0.3
+    groups = acct["groups"]
+    assert groups[0]["beta_delta"] == -0.5
+    assert groups[1]["beta_delta"] == 0.2
+    total = round(sum(g["beta_delta"] for g in groups if g["beta_delta"] is not None), 2)
+    assert acct["total_beta_delta"] == total
 

--- a/ui/src/app/positions/positions.models.ts
+++ b/ui/src/app/positions/positions.models.ts
@@ -1,4 +1,5 @@
 export interface Position {
+  beta?: number | null;
   [key: string]: any;
 }
 
@@ -9,6 +10,7 @@ export interface PositionGroup {
   current_group_p_l: number;
   percent_credit_received: number | null;
   total_delta?: number | null;
+  beta_delta?: number | null;
   iv_rank?: number | null;
   rules?: import('./positions.rules').RuleResult[];
   positions: Position[];


### PR DESCRIPTION
## Summary
- include position beta info in API schema
- calculate beta-weighted delta per group and expose on API
- expose beta field in UI models
- ensure account `total_beta_delta` equals sum of group beta deltas
- test coverage for new beta data

## Testing
- `pip install -r api/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858274b57ac832ebbac29e5cb2a4779