### PR TITLE
Fix API README code block

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -19,7 +19,7 @@ pytest
 
 ## Running the API locally on pycharm community edition
 ## make sure to create your virtual environment first and .env file is set up
-```aiignore
+```
 # cd into the api directory
 source .venv/bin/activate
 uvicorn app.main:app \
@@ -29,5 +29,6 @@ uvicorn app.main:app \
   --env-file /home/boots/code/trade-journal/.env
 ```
 
-
-```http://localhost:8876/docs```
+```
+http://localhost:8876/docs
+```


### PR DESCRIPTION
## Summary
- remove `aiignore` marker from local run command block
- close the docs URL in its own fenced code block and ensure the README ends with a newline

## Testing
- `pip install -r api/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6860bf625250832ebb35fd7a2afdc17d