### PR TITLE
Add Docker ignore files

### DIFF
--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -4,17 +4,12 @@
 # Node dependencies
 node_modules/
 
-# Build outputs
-/dist/
-/out-tsc/
-
-# Python cache or compiled files
+# Python cache and compiled files
 __pycache__/
 *.py[cod]
 
-# Test files and directories
+# Test directories
 /tests/
-**/*.spec.ts
 
 # Local configuration files
 .env


### PR DESCRIPTION
## Summary
- ignore node_modules, __pycache__, tests, and config files when building API and UI Docker images

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860bf691008832e8e5028263a91e8d8