### PR TITLE
Add timestamp to SpotGamma screenshots

### DIFF
--- a/api/app/routers/v1/spotgamma.py
+++ b/api/app/routers/v1/spotgamma.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException
 import os
 import base64
+from datetime import datetime
 from playwright.async_api import async_playwright
 
 HIRO_SPY_URL = "https://dashboard.spotgamma.com/hiro?eh-model=legacy&sym=S%26P+500"
@@ -45,4 +46,5 @@ async def hiro_screens():
 
         await browser.close()
 
-    return {"images": [img1, img2]}
+    timestamp = datetime.utcnow().isoformat() + "Z"
+    return {"timestamp": timestamp, "images": [img1, img2]}

--- a/ui/src/app/hiro/hiro-page/hiro-page.component.html
+++ b/ui/src/app/hiro/hiro-page/hiro-page.component.html
@@ -3,6 +3,11 @@
     Get Screens
   </button>
   <div class="screens">
-    <img *ngFor="let img of images" [src]="img" />
+    <div *ngFor="let screen of screens" class="screen-set">
+      <div class="screen-date">{{ screen.timestamp | date:'short' }}</div>
+      <div class="screen-row">
+        <img *ngFor="let img of screen.images" [src]="img" />
+      </div>
+    </div>
   </div>
 </div>

--- a/ui/src/app/hiro/hiro-page/hiro-page.component.scss
+++ b/ui/src/app/hiro/hiro-page/hiro-page.component.scss
@@ -4,8 +4,18 @@
   gap: 1rem;
 }
 
-.screens img {
+.screen-set {
+  margin-bottom: 2rem;
+}
+
+.screen-row {
+  display: flex;
+  gap: 1rem;
+}
+
+.screen-row img {
+  flex: 1;
   max-width: 100%;
-  margin-bottom: 1rem;
+  height: auto;
   border: 1px solid #ccc;
 }

--- a/ui/src/app/hiro/hiro-page/hiro-page.component.ts
+++ b/ui/src/app/hiro/hiro-page/hiro-page.component.ts
@@ -2,23 +2,32 @@ import { Component } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../environments/environment';
 
+interface HiroResponse {
+  timestamp: string;
+  images: string[];
+}
+
 @Component({
   selector: 'app-hiro-page',
   templateUrl: './hiro-page.component.html',
   styleUrls: ['./hiro-page.component.scss'],
   standalone: false,
 })
+
 export class HiroPageComponent {
-  images: string[] = [];
+  screens: { timestamp: string; images: string[] }[] = [];
   loading = false;
 
   constructor(private http: HttpClient) {}
 
   getScreens() {
     this.loading = true;
-    this.http.get<{images: string[]}>(`${environment.apiUrl}/spotgamma/hiro`).subscribe({
+    this.http.get<HiroResponse>(`${environment.apiUrl}/spotgamma/hiro`).subscribe({
       next: res => {
-        this.images.push(...res.images.map(img => 'data:image/png;base64,' + img));
+        this.screens.unshift({
+          timestamp: res.timestamp,
+          images: res.images.map(img => 'data:image/png;base64,' + img)
+        });
         this.loading = false;
       },
       error: () => {


### PR DESCRIPTION
## Summary
- include capture timestamp in spotgamma Hiro endpoint
- display timestamp on Hiro page and show screenshots side by side
- style Hiro page for responsive screenshot rows

## Testing
- `pytest`
- `npm test -- --watch=false`

------
https://chatgpt.com/codex/tasks/task_e_6861d9c5a80c832ebe319971da4fb050