### PR TITLE
Add filenames and downloadable Hiro screenshots

### DIFF
--- a/api/app/routers/v1/spotgamma.py
+++ b/api/app/routers/v1/spotgamma.py
@@ -50,8 +50,14 @@ async def hiro_screens():
 
         await browser.close()
 
-    timestamp = datetime.utcnow().isoformat() + "Z"
-    return {"timestamp": timestamp, "images": [img1, img2]}
+    ts = datetime.utcnow()
+    timestamp = ts.isoformat() + "Z"
+    safe_ts = ts.strftime("%Y%m%d-%H%M%S")
+    images = [
+        {"name": f"{safe_ts}-SP500.png", "data": img1},
+        {"name": f"{safe_ts}-SPEquities.png", "data": img2},
+    ]
+    return {"timestamp": timestamp, "images": images}
 
 
 def load_image(file: UploadFile) -> np.ndarray:

--- a/ui/src/app/hiro/hiro-page/hiro-page.component.html
+++ b/ui/src/app/hiro/hiro-page/hiro-page.component.html
@@ -6,7 +6,7 @@
     <div *ngFor="let screen of screens" class="screen-set">
       <div class="screen-date">{{ screen.timestamp | date:'short' }}</div>
       <div class="screen-row">
-        <img *ngFor="let img of screen.images" [src]="img" />
+        <img *ngFor="let img of screen.images" [src]="img.url" [alt]="img.name" (click)="downloadImage(img)" />
       </div>
     </div>
   </div>

--- a/ui/src/app/hiro/hiro-page/hiro-page.component.scss
+++ b/ui/src/app/hiro/hiro-page/hiro-page.component.scss
@@ -18,4 +18,5 @@
   max-width: 50%;
   height: auto;
   border: 1px solid #ccc;
+  cursor: pointer;
 }

--- a/ui/src/app/hiro/hiro-page/hiro-page.component.ts
+++ b/ui/src/app/hiro/hiro-page/hiro-page.component.ts
@@ -2,9 +2,14 @@ import { Component } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../environments/environment';
 
+interface HiroImage {
+  name: string;
+  data: string;
+}
+
 interface HiroResponse {
   timestamp: string;
-  images: string[];
+  images: HiroImage[];
 }
 
 @Component({
@@ -15,7 +20,7 @@ interface HiroResponse {
 })
 
 export class HiroPageComponent {
-  screens: { timestamp: string; images: string[] }[] = [];
+  screens: { timestamp: string; images: { name: string; url: string }[] }[] = [];
   loading = false;
 
   constructor(private http: HttpClient) {}
@@ -26,7 +31,10 @@ export class HiroPageComponent {
       next: res => {
         this.screens.unshift({
           timestamp: res.timestamp,
-          images: res.images.map(img => 'data:image/png;base64,' + img)
+          images: res.images.map(img => ({
+            name: img.name,
+            url: 'data:image/png;base64,' + img.data
+          }))
         });
         this.loading = false;
       },
@@ -34,5 +42,12 @@ export class HiroPageComponent {
         this.loading = false;
       }
     });
+  }
+
+  downloadImage(img: { name: string; url: string }) {
+    const link = document.createElement('a');
+    link.href = img.url;
+    link.download = img.name;
+    link.click();
   }
 }


### PR DESCRIPTION
## Summary
- return image names from the Hiro API
- display images with download on click

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862baaf4a94832e98409699dec31d65