### PR TITLE
Add cross check button to Hiro page

### DIFF
--- a/ui/src/app/hiro/hiro-page/hiro-page.component.html
+++ b/ui/src/app/hiro/hiro-page/hiro-page.component.html
@@ -4,9 +4,17 @@
   </button>
   <div class="screens">
     <div *ngFor="let screen of screens" class="screen-set">
-      <div class="screen-date">{{ screen.timestamp | date:'short' }}</div>
+      <div class="screen-header">
+        <div class="screen-date">{{ screen.timestamp | date:'short' }}</div>
+        <button mat-button (click)="detectCross(screen)" [disabled]="screen.checking">Check Cross</button>
+      </div>
       <div class="screen-row">
-        <img *ngFor="let img of screen.images" [src]="img.url" [alt]="img.name" (click)="downloadImage(img)" />
+        <div class="img-wrapper" *ngFor="let img of screen.images">
+          <img [src]="img.url" [alt]="img.name" (click)="downloadImage(img)" />
+          <div class="cross-result" *ngIf="img.crossing !== undefined">
+            {{ img.crossing ? 'Cross detected' : 'No cross' }}
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/ui/src/app/hiro/hiro-page/hiro-page.component.scss
+++ b/ui/src/app/hiro/hiro-page/hiro-page.component.scss
@@ -8,15 +8,34 @@
   margin-bottom: 2rem;
 }
 
+.screen-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+
 .screen-row {
   display: flex;
   gap: 1rem;
 }
 
-.screen-row img {
+.img-wrapper {
   flex: 1;
   max-width: 50%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.img-wrapper img {
+  width: 100%;
   height: auto;
   border: 1px solid #ccc;
   cursor: pointer;
+}
+
+.cross-result {
+  margin-top: 0.25rem;
+  font-size: 0.9rem;
 }


### PR DESCRIPTION
## Summary
- add `ScreenImage` and `ScreenSet` interfaces to track cross detection status
- create `detectCross` method to POST screenshots to `/spotgamma/detect-crossing`
- add a `Check Cross` button next to each timestamp
- display detection results under each image
- update layout styles for new controls

## Testing
- `pytest api/tests/test_hello_v1.py::test_hello_root -q`

------
https://chatgpt.com/codex/tasks/task_e_6863015df338832e97daff063ee1b409