### PR TITLE
Add spotgamma route tests and frontend unit tests

### DIFF
--- a/api/tests/test_spotgamma_v1.py
+++ b/api/tests/test_spotgamma_v1.py
@@ -1,0 +1,80 @@
+import base64
+from datetime import datetime as real_datetime
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_hiro_screens(client, monkeypatch):
+    class DummyLocator:
+        async def click(self):
+            pass
+
+    class DummyPage:
+        async def goto(self, url):
+            pass
+        async def wait_for_load_state(self, state):
+            pass
+        def get_by_role(self, *a, **kw):
+            return DummyLocator()
+        async def screenshot(self):
+            return b'data'
+        async def fill(self, *args, **kwargs):
+            pass
+    class DummyContext:
+        async def new_page(self):
+            return DummyPage()
+    class DummyBrowser:
+        async def new_context(self):
+            return DummyContext()
+        async def close(self):
+            pass
+    class DummyChromium:
+        async def launch(self, headless=True, args=None):
+            return DummyBrowser()
+    class DummyPlaywright:
+        def __init__(self):
+            self.chromium = DummyChromium()
+    class DummyManager:
+        async def __aenter__(self):
+            return DummyPlaywright()
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+    monkeypatch.setenv("SPOTGAMMA_USERNAME", "u")
+    monkeypatch.setenv("SPOTGAMMA_PASSWORD", "p")
+    import app.routers.v1.spotgamma as spg
+    monkeypatch.setattr(spg, "async_playwright", lambda: DummyManager())
+
+    async def fake_login(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(spg, "login", fake_login)
+    class FakeDateTime:
+        @classmethod
+        def utcnow(cls):
+            return real_datetime(2024, 1, 1, 0, 0, 0)
+
+    monkeypatch.setattr(spg, "datetime", FakeDateTime)
+
+    resp = await client.get("/v1/spotgamma/hiro")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "timestamp" in data and "images" in data
+    assert len(data["images"]) == 2
+    names = [img["name"] for img in data["images"]]
+    assert names[0].endswith("SP500.png")
+    assert base64.b64decode(data["images"][0]["data"]) == b"data"
+
+
+@pytest.mark.asyncio
+async def test_detect_crossing(client, monkeypatch):
+    def fake_load(f):
+        return f.filename
+    def fake_detect(img):
+        return img == "a"
+    monkeypatch.setattr("app.routers.v1.spotgamma.load_image", fake_load)
+    monkeypatch.setattr("app.routers.v1.spotgamma.detect_cross", fake_detect)
+    files = {"img1": ("a", b"foo", "image/png"), "img2": ("b", b"bar", "image/png")}
+    resp = await client.post("/v1/spotgamma/detect-crossing", files=files)
+    assert resp.status_code == 200
+    assert resp.json() == {"a": True, "b": False}

--- a/ui/src/app/dashboard/dashboard-data.spec.ts
+++ b/ui/src/app/dashboard/dashboard-data.spec.ts
@@ -1,0 +1,12 @@
+import { tradeGuidelines, dailyOverviewAnalysis } from './dashboard-data';
+
+describe('dashboard data', () => {
+  it('contains tastytrade guideline', () => {
+    expect(tradeGuidelines).toContain('Follow the tastytrade rules');
+  });
+
+  it('includes tradingview link', () => {
+    const found = dailyOverviewAnalysis.find(r => r.name === 'TradingView ES1!');
+    expect(found?.url).toContain('tradingview.com');
+  });
+});

--- a/ui/src/app/shared/loading.service.spec.ts
+++ b/ui/src/app/shared/loading.service.spec.ts
@@ -1,0 +1,33 @@
+import { LoadingService } from './loading.service';
+
+describe('LoadingService', () => {
+  let service: LoadingService;
+
+  beforeEach(() => {
+    service = new LoadingService();
+  });
+
+  it('emits true on first show and false after hide', () => {
+    const values: boolean[] = [];
+    const sub = service.loading$.subscribe(v => values.push(v));
+
+    service.show();
+    service.hide();
+
+    expect(values).toEqual([false, true, false]);
+    sub.unsubscribe();
+  });
+
+  it('only toggles when count drops to zero', () => {
+    let last = false;
+    const sub = service.loading$.subscribe(v => last = v);
+
+    service.show();
+    service.show();
+    service.hide();
+    expect(last).toBeTrue();
+    service.hide();
+    expect(last).toBeFalse();
+    sub.unsubscribe();
+  });
+});


### PR DESCRIPTION
## Summary
- add API tests for the new `spotgamma` routes
- cover custom frontend logic with tests
- include simple LoadingService and dashboard-data specs

## Testing
- `pip install -r api/requirements.txt`
- `pytest -q`
- `npm ci`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_686304a09278832ead0a30429baf9a99